### PR TITLE
Upgrade to python3.12

### DIFF
--- a/cftemplates/snapshots_tool_aurora_dest.json
+++ b/cftemplates/snapshots_tool_aurora_dest.json
@@ -400,7 +400,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.12",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}
@@ -442,7 +442,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.12",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}

--- a/cftemplates/snapshots_tool_aurora_source.json
+++ b/cftemplates/snapshots_tool_aurora_source.json
@@ -402,7 +402,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.12",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}
@@ -447,7 +447,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.12",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}
@@ -492,7 +492,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.12",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}


### PR DESCRIPTION
Upgrade: python 3.7 -> 3.12

Python 3.7 went out of support and is subject to [runtime use after deprecation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-deprecation-levels) restrictions like AWS blocking updates.